### PR TITLE
Fix layout on mobile

### DIFF
--- a/code.js
+++ b/code.js
@@ -266,28 +266,18 @@ $(document).ready(function() {
 		// Resize map
 		scr_w = document.body.clientWidth;
 		scr_h = document.body.clientHeight;
-		if (scr_w > 840 && scr_h > 620) {
-			var infotab = document.getElementById("infotab");
-			var hasVerticalScrollbar = infotab.scrollHeight > infotab.clientHeight;
-			var scrollBarWidth = 0;
-			if (hasVerticalScrollbar) {
-				var scrollBarWidth = infotab.offsetWidth - infotab.clientWidth;
-			}
-			$("#infotab").css("width", 210 + scrollBarWidth);
-			var infotab_w = $("#infotab").outerWidth();
-			$("#mapscreen #bg").css("max-width", scr_w - infotab_w);
-			$("#mapscreen #bg").css("max-height", scr_h);
-			$("body").css("overflow-x", "hidden");
-			$("body").css("overflow-y", "hidden");
-			$("body").addClass("hide_scroll");
+
+		if (scr_w > 600) {
+			$("body").removeClass("mobile");
+			$("body").addClass("desktop");
+			$("#mapscreen #bg").css("max-width", scr_w - 220);
+		} else {
+			$("body").removeClass("desktop");
+			$("body").addClass("mobile");
+			$("#mapscreen #bg").css("max-width", scr_w);
 		}
-		else {
-			$("#mapscreen #bg").css("max-width", Math.max(scr_w, 620));
-			$("#mapscreen #bg").css("max-height", Math.max(scr_w, 620));
-			$("body").css("overflow-x", "auto");
-			$("body").css("overflow-y", "scroll");
-			$("body").removeClass("hide_scroll");
-		}
+		$("#mapscreen #bg").css("max-height", scr_h);
+
 		// Make overlay same size as map
 		map_w = $("#mapscreen #bg").width();
 		map_h = $("#mapscreen #bg").height();

--- a/css/style.css
+++ b/css/style.css
@@ -469,7 +469,6 @@ input[type=range]::-ms-fill-upper {
 	max-height: 100vh;
 }
 .desktop #infotab {
-	overflow-y: scroll;
 	width: 220px;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -20,7 +20,16 @@ body {
 	scrollbar-width: thin;
     -ms-overflow-style: none;	/* IE 10+ */
 }
-body.hide_scroll::-webkit-scrollbar {		/* WebKit */
+body.desktop {
+	overflow-x: hidden;
+	overflow-y: hidden;
+}
+body.mobile {
+	overflow-x: auto;
+	overflow-y: scroll;
+}
+
+body.desktop::-webkit-scrollbar {		/* WebKit */
     width: 0;
     height: 0;
 }
@@ -209,8 +218,17 @@ input[type=range]::-ms-fill-upper {
 
 /* WRAPPER */
 #wrapper {
+	display: flex;
 	max-width: 100%;
+}
+
+.desktop #wrapper {
 	max-height: 100%;
+	flex-direction: row;
+}
+
+.mobile #wrapper {
+	flex-direction: column;
 }
 
 /* MAP */
@@ -296,12 +314,18 @@ input[type=range]::-ms-fill-upper {
 	background-color: #000;
 	border: 1px solid #CC212C;
 	position: absolute;
-	width: 600px;
 	min-height: 200px;
+	display: none;
+}
+
+.desktop #notification {
+	width: 600px;
 	top: 50%;
 	left: 50%;
 	margin-left: -300px;
-	display: none;
+}
+.mobile #notification {
+	width: 100%;
 }
 #notification > div {
 	height: 100%;
@@ -444,10 +468,15 @@ input[type=range]::-ms-fill-upper {
 	overflow-y: auto;
 	max-height: 100vh;
 }
+.desktop #infotab {
+	overflow-y: scroll;
+	width: 220px;
+}
+
 .information {
 	border: 1px solid black;
 	padding: 5px;
-	width: 200px;
+	width: 100%;
 	margin-bottom: 5px;
 }
 .information:last-child {

--- a/index.html
+++ b/index.html
@@ -29,404 +29,406 @@
 
 <body>
 	<div id="wrapper">
-		<div id="mapscreen" class="col">
-			<audio id="notification_ding" src="sfx/chime.mp3"></audio>
-			<img id="bg" src="img/bg.jpg" draggable="false"/>
-			<img id="bunker_map" src="img/bunker.png" class="map_icon clickable"/>
-			<img id="coke_map" src="img/coke.png" class="map_icon clickable"/>
-			<img id="meth_map" src="img/meth.png" class="map_icon clickable"/>
-			<img id="cash_map" src="img/cash.png" class="map_icon clickable"/>
-			<img id="weed_map" src="img/weed.png" class="map_icon clickable"/>
-			<img id="forgery_map" src="img/forgery.png" class="map_icon clickable"/>
-			<img id="nightclub_map" src="img/nightclub.png" class="map_icon clickable"/>
-			<img id="importExport_map" src="img/import.png" class="map_icon"/>
-			<img id="wheel_map" src="img/wheel.png" class="map_icon clickable"/>
-			<div id="mini_notif">
-				<p>The business manager is paused.</p>
-			</div>
-			<div id="options" class="fsz">
-				<button class="button toggle start green">Start</button>
-				<button class="button audio red">Sound</button>
-				<button class="button setup red">Setup</button>
-			</div>
-			<div id="overlay"></div>
-			<div id="notification">
-				<div id="updateNotice">
-					<div class="heading">
-						<h1>Patch Notes</h1>
-					</div>
-					<div class="main">
-						<h1>Version 1.4.0</h1>
-						<div class="indent">
-							<h2>New features</h2>
-							<ul>
-								<li>Businesses can now be individually muted by clicking on their map icon.</li>
-								<li>The Lucky Wheel can now be hidden via its setup.</li>
-								<li>Added button to view these patch notes again to the main setup.</li>
-							</ul>
-							<h2>Fixes</h2>
-							<ul>
-								<li>Bunker research bar should now be calculated correctly.
-									<ul><li>Projected times with time remaining bar style may still be incorrect for bunker research.</li></ul>
-								</li>
-								<li>Increased contrast of progress bar text (for percentage and time remaining styles).</li>
-								<li>Potential fix for notification sound not playing on some browsers.</li>
-							</ul>
+		<div id="mapbox">
+			<div id="mapscreen" class="col">
+				<audio id="notification_ding" src="sfx/chime.mp3"></audio>
+				<img id="bg" src="img/bg.jpg" draggable="false"/>
+				<img id="bunker_map" src="img/bunker.png" class="map_icon clickable"/>
+				<img id="coke_map" src="img/coke.png" class="map_icon clickable"/>
+				<img id="meth_map" src="img/meth.png" class="map_icon clickable"/>
+				<img id="cash_map" src="img/cash.png" class="map_icon clickable"/>
+				<img id="weed_map" src="img/weed.png" class="map_icon clickable"/>
+				<img id="forgery_map" src="img/forgery.png" class="map_icon clickable"/>
+				<img id="nightclub_map" src="img/nightclub.png" class="map_icon clickable"/>
+				<img id="importExport_map" src="img/import.png" class="map_icon"/>
+				<img id="wheel_map" src="img/wheel.png" class="map_icon clickable"/>
+				<div id="mini_notif">
+					<p>The business manager is paused.</p>
+				</div>
+				<div id="options" class="fsz">
+					<button class="button toggle start green">Start</button>
+					<button class="button audio red">Sound</button>
+					<button class="button setup red">Setup</button>
+				</div>
+				<div id="overlay"></div>
+				<div id="notification">
+					<div id="updateNotice">
+						<div class="heading">
+							<h1>Patch Notes</h1>
+						</div>
+						<div class="main">
+							<h1>Version 1.4.0</h1>
+							<div class="indent">
+								<h2>New features</h2>
+								<ul>
+									<li>Businesses can now be individually muted by clicking on their map icon.</li>
+									<li>The Lucky Wheel can now be hidden via its setup.</li>
+									<li>Added button to view these patch notes again to the main setup.</li>
+								</ul>
+								<h2>Fixes</h2>
+								<ul>
+									<li>Bunker research bar should now be calculated correctly.
+										<ul><li>Projected times with time remaining bar style may still be incorrect for bunker research.</li></ul>
+									</li>
+									<li>Increased contrast of progress bar text (for percentage and time remaining styles).</li>
+									<li>Potential fix for notification sound not playing on some browsers.</li>
+								</ul>
+							</div>
+						</div>
+						<div class="buttons">
+							<button class="button ok red">OK</button>
 						</div>
 					</div>
-					<div class="buttons">
-						<button class="button ok red">OK</button>
+					<div id="pauseNotice">
+						<div class="heading">
+							<h1>Notice</h1>
+						</div>
+						<div class="main">
+							<p>The business manager is currently paused. It should be unpaused at all times
+							when you are in free roam / contact missions in order to be accurate.</p>
+						</div>
+						<div class="buttons fsz">
+							<button class="button ok red">OK</button>
+						</div>
 					</div>
-				</div>
-				<div id="pauseNotice">
-					<div class="heading">
-						<h1>Notice</h1>
+					<div id="mainSetup" class="setupGUI">
+						<div class="heading">
+							<h1>Setup</h1>
+						</div>
+						<div class="main">
+							<table>
+								<tr class="hideUnowned">
+									<td>Hide unowned:</td>
+									<td class="onechoice fsz">
+										<button class="button green" data-value="1">Yes</button>
+										<button class="button red" data-value="0">No</button>
+									</td>
+								</tr>
+								<tr class="audioFreq">
+									<td>Audio interval:</td>
+									<td class="incDecButtons">
+										<button class="fa fa-minus button minus"></button><!--
+										--><input type="number" class="range_enforced integer_only" name="quantity" value="1" min="1" max="60"/><!--
+										--><button class="fa fa-plus button plus"></button><!--
+										--><span>minutes</span>
+									</td>
+								</tr>
+								<tr class="audioVolume">
+									<td>Audio volume:</td>
+									<td class="onechoice">
+										<input type="range" min="0" max="100" value="0"><!--
+										--><span>100%</span>
+									</td>
+								</tr>
+								<tr class="progressBarStyle">
+									<td>Progress style:</td>
+									<td class="onechoice fsz">
+										<button class="button blue" data-value="0">Compact</button>
+										<button class="button blue" data-value="1">5-tick</button>
+										<button class="button blue" data-value="2">Percentage</button>
+										<button class="button blue" data-value="3">Time Remaining</button>
+									</td>
+								</tr>
+								<tr class="dataDownload">
+									<td>Data:</td>
+									<td class="fsz">
+										<button class="button orange" data-value="0">Download</button>
+										<button class="button orange" data-value="1">Load from file</button>
+										<a id="dataDownloadLink" style="display: none;"></a>
+										<input id="fileInput" type="file" accept=".json, application/json" style="display: none;"/>
+									</td>
+								</tr>
+								<tr class="about">
+									<td>About:</td>
+									<td class="fsz">
+										<button class="button orange" data-value="0">Patch notes</button>
+									</td>
+								</tr>
+							</table>
+						</div>
+						<div class="buttons fsz">
+							<button class="button reset red">Reset Everything</button>
+							<button class="button cancel red">Cancel</button>
+							<button class="button apply red">Apply</button>
+						</div>
 					</div>
-					<div class="main">
-						<p>The business manager is currently paused. It should be unpaused at all times
-						when you are in free roam / contact missions in order to be accurate.</p>
+					<div id="resetWarning">
+						<div class="heading">
+							<h1>Warning</h1>
+						</div>
+						<div class="main">
+							<p>This will reset everything! Are you sure you want to continue?</p>
+						</div>
+						<div class="buttons fsz">
+							<button class="button cancel red">Cancel</button>
+							<button class="button reset red">Reset</button>
+						</div>
 					</div>
-					<div class="buttons fsz">
-						<button class="button ok red">OK</button>
+					<div id="nightclubGUI">
+						<div class="heading">
+							<h1>Nightclub Manager</h1>
+						</div>
+						<div class="main">
+							<table>
+								<tr>
+									<th>Product Name</th>
+									<th>Stock</th>
+									<th>Sell</th>
+								</tr>
+								<tr class="cargo">
+									<td>Cargo and Shipments</td>
+									<td></td>
+									<td class="incDecButtons">
+										<button class="fa fa-minus button minus"></button>
+										<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="50"/>
+										<button class="fa fa-plus button plus"></button>
+									</td>
+								</tr>
+								<tr class="sporting">
+									<td>Sporting Goods</td>
+									<td></td>
+									<td class="incDecButtons">
+										<button class="fa fa-minus button minus"></button>
+										<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="100"/>
+										<button class="fa fa-plus button plus"></button>
+									</td>
+								</tr>
+								<tr class="imports">
+									<td>South American Imports</td>
+									<td></td>
+									<td class="incDecButtons">
+										<button class="fa fa-minus button minus"></button>
+										<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="10"/>
+										<button class="fa fa-plus button plus"></button>
+									</td>
+								</tr>
+								<tr class="pharma">
+									<td>Pharmaceutical Research</td>
+									<td></td>
+									<td class="incDecButtons">
+										<button class="fa fa-minus button minus"></button>
+										<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="20"/>
+										<button class="fa fa-plus button plus"></button>
+									</td>
+								</tr>
+								<tr class="creation">
+									<td>Cash Creation</td>
+									<td></td>
+									<td class="incDecButtons fsz">
+										<button class="fa fa-minus button minus"></button>
+										<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="40"/>
+										<button class="fa fa-plus button plus"></button>
+									</td>
+								</tr>
+								<tr class="organic">
+									<td>Organic Produce</td>
+									<td></td>
+									<td class="incDecButtons fsz">
+										<button class="fa fa-minus button minus"></button>
+										<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="80"/>
+										<button class="fa fa-plus button plus"></button>
+									</td>
+								</tr>
+								<tr class="copying">
+									<td>Printing and Copying</td>
+									<td></td>
+									<td class="incDecButtons fsz">
+										<button class="fa fa-minus button minus"></button>
+										<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="60"/>
+										<button class="fa fa-plus button plus"></button>
+									</td>
+								</tr>
+							</table>
+						</div>
+						<div class="buttons fsz">
+							<button class="button sellsome red">Sell Selected</button>
+							<button class="button sell red">Sell All</button>
+							<button class="button ok red">Close</button>
+						</div>
 					</div>
-				</div>
-				<div id="mainSetup" class="setupGUI">
-					<div class="heading">
-						<h1>Setup</h1>
+					<div id="bunkerSetupGUI" class="setupGUI bunker">
+						<div class="heading">
+							<h1>Bunker Setup</h1>
+						</div>
+						<div class="main">
+							<table>
+								<tr class="own">
+									<td>Owned:</td>
+									<td class="onechoice fsz">
+										<button class="button green" data-value="1">Yes</button>
+										<button class="button red" data-value="0">No</button>
+									</td>
+								</tr>
+								<tr class="position">
+									<td>Map location:</td>
+									<td class="fsz">
+										<button class="button blue">Set Location</button>
+									</td>
+								</tr>
+								<tr class="hide_research">
+									<td>Hide research:</td>
+									<td class="onechoice fsz">
+										<button class="button green">Yes</button>
+										<button class="button red">No</button>
+									</td>
+								</tr>
+								<tr class="mode">
+									<td>Bunker mode:</td>
+									<td class="onechoice fsz">
+										<button class="button orange" data-value="0">Manufacturing</button>
+										<button class="button blue" data-value="1">Both</button>
+										<button class="button green" data-value="2">Researching</button><br/>
+									</td>
+								</tr>
+							</table>
+						</div>
+						<div class="buttons fsz">
+							<button class="button cancel red">Cancel</button>
+							<button class="button apply red">Apply</button>
+						</div>
 					</div>
-					<div class="main">
-						<table>
-							<tr class="hideUnowned">
-								<td>Hide unowned:</td>
-								<td class="onechoice fsz">
-									<button class="button green" data-value="1">Yes</button>
-									<button class="button red" data-value="0">No</button>
-								</td>
-							</tr>
-							<tr class="audioFreq">
-								<td>Audio interval:</td>
-								<td class="incDecButtons">
-									<button class="fa fa-minus button minus"></button><!--
-									--><input type="number" class="range_enforced integer_only" name="quantity" value="1" min="1" max="60"/><!--
-									--><button class="fa fa-plus button plus"></button><!--
-									--><span>minutes</span>
-								</td>
-							</tr>
-							<tr class="audioVolume">
-								<td>Audio volume:</td>
-								<td class="onechoice">
-									<input type="range" min="0" max="100" value="0"><!--
-									--><span>100%</span>
-								</td>
-							</tr>
-							<tr class="progressBarStyle">
-								<td>Progress style:</td>
-								<td class="onechoice fsz">
-									<button class="button blue" data-value="0">Compact</button>
-									<button class="button blue" data-value="1">5-tick</button>
-									<button class="button blue" data-value="2">Percentage</button>
-									<button class="button blue" data-value="3">Time Remaining</button>
-								</td>
-							</tr>
-							<tr class="dataDownload">
-								<td>Data:</td>
-								<td class="fsz">
-									<button class="button orange" data-value="0">Download</button>
-									<button class="button orange" data-value="1">Load from file</button>
-									<a id="dataDownloadLink" style="display: none;"></a>
-									<input id="fileInput" type="file" accept=".json, application/json" style="display: none;"/>
-								</td>
-							</tr>
-							<tr class="about">
-								<td>About:</td>
-								<td class="fsz">
-									<button class="button orange" data-value="0">Patch notes</button>
-								</td>
-							</tr>
-						</table>
+					<div id="mcbusinessSetupGUI" class="setupGUI">
+						<div class="heading">
+							<h1>MCBUSINESS Setup</h1>
+						</div>
+						<div class="main">
+							<table>
+								<tr class="own">
+									<td>Owned:</td>
+									<td class="onechoice fsz">
+										<button class="button green" data-value="1">Yes</button>
+										<button class="button red" data-value="0">No</button>
+									</td>
+								</tr>
+								<tr class="position">
+									<td>Map location:</td>
+									<td class="fsz">
+										<button class="button blue">Set Location</button>
+									</td>
+								</tr>
+							</table>
+						</div>
+						<div class="buttons fsz">
+							<button class="button cancel red">Cancel</button>
+							<button class="button apply red">Apply</button>
+						</div>
 					</div>
-					<div class="buttons fsz">
-						<button class="button reset red">Reset Everything</button>
-						<button class="button cancel red">Cancel</button>
-						<button class="button apply red">Apply</button>
+					<div id="nightclubSetupGUI" class="setupGUI nightclub">
+						<div class="heading">
+							<h1>Nightclub Setup</h1>
+						</div>
+						<div class="main">
+							<table>
+								<tr class="own">
+									<td>Owned:</td>
+									<td class="onechoice fsz">
+										<button class="button green" data-value="1">Yes</button>
+										<button class="button red" data-value="0">No</button>
+									</td>
+								</tr>
+								<tr class="position">
+									<td>Map location:</td>
+									<td class="fsz">
+										<button class="button blue">Set Location</button>
+									</td>
+								</tr>
+								<tr class="sidebar">
+									<td>Sidebar:</td>
+									<td class="onechoice fsz">
+										<button class="button green" data-value="1">Show all</button>
+										<button class="button orange" data-value="0">Show produced</button>
+									</td>
+								</tr>
+								<tr class="producing">
+									<td>Producing:</td>
+									<td class="indivchoice fsz">
+										<button class="button blue" data-value="cargo">Cargo and Shipments</button>
+										<button class="button blue" data-value="sporting">Sporting Goods</button>
+										<button class="button blue" data-value="imports">South American Imports</button>
+										<button class="button blue" data-value="pharma">Pharmaceutical Research</button>
+										<button class="button blue" data-value="creation">Cash Creation</button>
+										<button class="button blue" data-value="organic">Organic Produce</button>
+										<button class="button blue" data-value="copying">Printing and Copying</button>
+									</td>
+								</tr>
+							</table>
+						</div>
+						<div class="buttons fsz">
+							<button class="button cancel red">Cancel</button>
+							<button class="button apply red">Apply</button>
+						</div>
 					</div>
-				</div>
-				<div id="resetWarning">
-					<div class="heading">
-						<h1>Warning</h1>
+					<div id="importExportSetupGUI" class="setupGUI importExport">
+						<div class="heading">
+							<h1>Import / Export Setup</h1>
+						</div>
+						<div class="main">
+							<table>
+								<tr class="own">
+									<td>Owned:</td>
+									<td class="onechoice fsz">
+										<button class="button green" data-value="1">Yes</button>
+										<button class="button red" data-value="0">No</button>
+									</td>
+								</tr>
+								<tr class="position">
+									<td>Map location:</td>
+									<td class="fsz">
+										<button class="button blue">Set Location</button>
+									</td>
+								</tr>
+								<tr class="highEndCars">
+									<td>High-end cars:</td>
+									<td class="incDecButtons fsz">
+										<button class="fa fa-minus button minus"></button>
+										<input type="number" class="range_enforced" name="quantity" value="0" min="0" max="20"/>
+										<button class="fa fa-plus button plus"></button>
+									</td>
+								</tr>
+								<tr class="resetCooldown">
+									<td>Cooldown:</td>
+									<td class="fsz">
+										<button class="button blue">Reset</button>
+									</td>
+								</tr>
+							</table>
+						</div>
+						<div class="buttons fsz">
+							<button class="button cancel red">Cancel</button>
+							<button class="button apply red">Apply</button>
+						</div>
 					</div>
-					<div class="main">
-						<p>This will reset everything! Are you sure you want to continue?</p>
-					</div>
-					<div class="buttons fsz">
-						<button class="button cancel red">Cancel</button>
-						<button class="button reset red">Reset</button>
-					</div>
-				</div>
-				<div id="nightclubGUI">
-					<div class="heading">
-						<h1>Nightclub Manager</h1>
-					</div>
-					<div class="main">
-						<table>
-							<tr>
-								<th>Product Name</th>
-								<th>Stock</th>
-								<th>Sell</th>
-							</tr>
-							<tr class="cargo">
-								<td>Cargo and Shipments</td>
-								<td></td>
-								<td class="incDecButtons">
-									<button class="fa fa-minus button minus"></button>
-									<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="50"/>
-									<button class="fa fa-plus button plus"></button>
-								</td>
-							</tr>
-							<tr class="sporting">
-								<td>Sporting Goods</td>
-								<td></td>
-								<td class="incDecButtons">
-									<button class="fa fa-minus button minus"></button>
-									<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="100"/>
-									<button class="fa fa-plus button plus"></button>
-								</td>
-							</tr>
-							<tr class="imports">
-								<td>South American Imports</td>
-								<td></td>
-								<td class="incDecButtons">
-									<button class="fa fa-minus button minus"></button>
-									<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="10"/>
-									<button class="fa fa-plus button plus"></button>
-								</td>
-							</tr>
-							<tr class="pharma">
-								<td>Pharmaceutical Research</td>
-								<td></td>
-								<td class="incDecButtons">
-									<button class="fa fa-minus button minus"></button>
-									<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="20"/>
-									<button class="fa fa-plus button plus"></button>
-								</td>
-							</tr>
-							<tr class="creation">
-								<td>Cash Creation</td>
-								<td></td>
-								<td class="incDecButtons fsz">
-									<button class="fa fa-minus button minus"></button>
-									<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="40"/>
-									<button class="fa fa-plus button plus"></button>
-								</td>
-							</tr>
-							<tr class="organic">
-								<td>Organic Produce</td>
-								<td></td>
-								<td class="incDecButtons fsz">
-									<button class="fa fa-minus button minus"></button>
-									<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="80"/>
-									<button class="fa fa-plus button plus"></button>
-								</td>
-							</tr>
-							<tr class="copying">
-								<td>Printing and Copying</td>
-								<td></td>
-								<td class="incDecButtons fsz">
-									<button class="fa fa-minus button minus"></button>
-									<input type="number" class="range_enforced integer_only" name="quantity" value="0" min="0" max="60"/>
-									<button class="fa fa-plus button plus"></button>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div class="buttons fsz">
-						<button class="button sellsome red">Sell Selected</button>
-						<button class="button sell red">Sell All</button>
-						<button class="button ok red">Close</button>
-					</div>
-				</div>
-				<div id="bunkerSetupGUI" class="setupGUI bunker">
-					<div class="heading">
-						<h1>Bunker Setup</h1>
-					</div>
-					<div class="main">
-						<table>
-							<tr class="own">
-								<td>Owned:</td>
-								<td class="onechoice fsz">
-									<button class="button green" data-value="1">Yes</button>
-									<button class="button red" data-value="0">No</button>
-								</td>
-							</tr>
-							<tr class="position">
-								<td>Map location:</td>
-								<td class="fsz">
-									<button class="button blue">Set Location</button>
-								</td>
-							</tr>
-							<tr class="hide_research">
-								<td>Hide research:</td>
-								<td class="onechoice fsz">
-									<button class="button green">Yes</button>
-									<button class="button red">No</button>
-								</td>
-							</tr>
-							<tr class="mode">
-								<td>Bunker mode:</td>
-								<td class="onechoice fsz">
-									<button class="button orange" data-value="0">Manufacturing</button>
-									<button class="button blue" data-value="1">Both</button>
-									<button class="button green" data-value="2">Researching</button><br/>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div class="buttons fsz">
-						<button class="button cancel red">Cancel</button>
-						<button class="button apply red">Apply</button>
-					</div>
-				</div>
-				<div id="mcbusinessSetupGUI" class="setupGUI">
-					<div class="heading">
-						<h1>MCBUSINESS Setup</h1>
-					</div>
-					<div class="main">
-						<table>
-							<tr class="own">
-								<td>Owned:</td>
-								<td class="onechoice fsz">
-									<button class="button green" data-value="1">Yes</button>
-									<button class="button red" data-value="0">No</button>
-								</td>
-							</tr>
-							<tr class="position">
-								<td>Map location:</td>
-								<td class="fsz">
-									<button class="button blue">Set Location</button>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div class="buttons fsz">
-						<button class="button cancel red">Cancel</button>
-						<button class="button apply red">Apply</button>
-					</div>
-				</div>
-				<div id="nightclubSetupGUI" class="setupGUI nightclub">
-					<div class="heading">
-						<h1>Nightclub Setup</h1>
-					</div>
-					<div class="main">
-						<table>
-							<tr class="own">
-								<td>Owned:</td>
-								<td class="onechoice fsz">
-									<button class="button green" data-value="1">Yes</button>
-									<button class="button red" data-value="0">No</button>
-								</td>
-							</tr>
-							<tr class="position">
-								<td>Map location:</td>
-								<td class="fsz">
-									<button class="button blue">Set Location</button>
-								</td>
-							</tr>
-							<tr class="sidebar">
-								<td>Sidebar:</td>
-								<td class="onechoice fsz">
-									<button class="button green" data-value="1">Show all</button>
-									<button class="button orange" data-value="0">Show produced</button>
-								</td>
-							</tr>
-							<tr class="producing">
-								<td>Producing:</td>
-								<td class="indivchoice fsz">
-									<button class="button blue" data-value="cargo">Cargo and Shipments</button>
-									<button class="button blue" data-value="sporting">Sporting Goods</button>
-									<button class="button blue" data-value="imports">South American Imports</button>
-									<button class="button blue" data-value="pharma">Pharmaceutical Research</button>
-									<button class="button blue" data-value="creation">Cash Creation</button>
-									<button class="button blue" data-value="organic">Organic Produce</button>
-									<button class="button blue" data-value="copying">Printing and Copying</button>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div class="buttons fsz">
-						<button class="button cancel red">Cancel</button>
-						<button class="button apply red">Apply</button>
-					</div>
-				</div>
-				<div id="importExportSetupGUI" class="setupGUI importExport">
-					<div class="heading">
-						<h1>Import / Export Setup</h1>
-					</div>
-					<div class="main">
-						<table>
-							<tr class="own">
-								<td>Owned:</td>
-								<td class="onechoice fsz">
-									<button class="button green" data-value="1">Yes</button>
-									<button class="button red" data-value="0">No</button>
-								</td>
-							</tr>
-							<tr class="position">
-								<td>Map location:</td>
-								<td class="fsz">
-									<button class="button blue">Set Location</button>
-								</td>
-							</tr>
-							<tr class="highEndCars">
-								<td>High-end cars:</td>
-								<td class="incDecButtons fsz">
-									<button class="fa fa-minus button minus"></button>
-									<input type="number" class="range_enforced" name="quantity" value="0" min="0" max="20"/>
-									<button class="fa fa-plus button plus"></button>
-								</td>
-							</tr>
-							<tr class="resetCooldown">
-								<td>Cooldown:</td>
-								<td class="fsz">
-									<button class="button blue">Reset</button>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div class="buttons fsz">
-						<button class="button cancel red">Cancel</button>
-						<button class="button apply red">Apply</button>
-					</div>
-				</div>
-				<div id="wheelSetupGUI" class="setupGUI wheel">
-					<div class="heading">
-						<h1>Lucky Wheel Setup</h1>
-					</div>
-					<div class="main">
-						<table>
-							<tr class="own">
-								<td>Display:</td>
-								<td class="onechoice fsz">
-									<button class="button green" data-value="1">Yes</button>
-									<button class="button red" data-value="0">No</button>
-								</td>
-							</tr>
-							<tr class="resetCooldown">
-								<td>Cooldown:</td>
-								<td class="fsz">
-									<button class="button blue">Reset</button>
-								</td>
-							</tr>
-						</table>
-					</div>
-					<div class="buttons fsz">
-						<button class="button cancel red">Cancel</button>
-						<button class="button apply red">Apply</button>
+					<div id="wheelSetupGUI" class="setupGUI wheel">
+						<div class="heading">
+							<h1>Lucky Wheel Setup</h1>
+						</div>
+						<div class="main">
+							<table>
+								<tr class="own">
+									<td>Display:</td>
+									<td class="onechoice fsz">
+										<button class="button green" data-value="1">Yes</button>
+										<button class="button red" data-value="0">No</button>
+									</td>
+								</tr>
+								<tr class="resetCooldown">
+									<td>Cooldown:</td>
+									<td class="fsz">
+										<button class="button blue">Reset</button>
+									</td>
+								</tr>
+							</table>
+						</div>
+						<div class="buttons fsz">
+							<button class="button cancel red">Cancel</button>
+							<button class="button apply red">Apply</button>
+						</div>
 					</div>
 				</div>
 			</div>
 		</div>
 		<div id="infotab" class="col">
-			<div id="activeBusinesses">
+			<div class="business-section" id="activeBusinesses">
 				<div id="bunker" class="information">
 					<div class="business_heading clearfix">
 						<img src="img/bunker.png" class="icon"/>
@@ -788,7 +790,7 @@
 					<button class="button purple" disabled="true">Not in Session</button>
 				</div>
 			</div>
-			<div id="inactiveBusinesses"></div>
+			<div class="business-section" id="inactiveBusinesses"></div>
 		</div>
 	</div>
 </body>


### PR DESCRIPTION
- Use flexbox to position the map and info panel
- Create `.mobile` and `.desktop` classes that are set depending on browser width
  - This should probably be replaced with `@media` queries
- Switch between row and column placement for mobile
- Make modal window full width on mobile